### PR TITLE
Rc-1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+## 1.2.0 - 2022-07-19
+
+### Added
+
+- New endpoint `POST /sapi/v3/asset/getUserAsset`
+- New endpoint `GET /sapi/v1/margin/dribblet`
+
+### Update
+
+- Updated endpoint `GET /sapi/v1/convert/tradeFlow` weight
+
 ## 1.1.0 - 2022-07-07
 
 ### Add

--- a/examples/spot/margin/marginDustLog.php
+++ b/examples/spot/margin/marginDustLog.php
@@ -1,0 +1,21 @@
+<?php
+
+require_once __DIR__ . '/../../../vendor/autoload.php';
+
+$key = '';
+$secret = '';
+
+$client = new \Binance\Spot([
+    'key'  => $key,
+    'secret'  => $secret
+]);
+
+$response = $client->marginDustLog(
+    [
+        'startTime' => 1640995200000,
+        'endTime' => 1640995200000,
+        'recvWindow' => 5000
+    ]
+);
+
+echo json_encode($response);

--- a/examples/spot/wallet/userAsset.php
+++ b/examples/spot/wallet/userAsset.php
@@ -1,0 +1,15 @@
+<?php
+
+require_once __DIR__ . '/../../../vendor/autoload.php';
+
+$key = '';
+$secret = '';
+
+$client = new \Binance\Spot([
+    'key'  => $key,
+    'secret'  => $secret
+]);
+
+$response = $client->userAsset();
+
+echo json_encode($response);

--- a/src/Binance/Spot/Convert.php
+++ b/src/Binance/Spot/Convert.php
@@ -11,7 +11,7 @@ trait Convert
      *
      * - The max interval between startTime and endTime is 30 days.
      *
-     * Weight(UID): 3000
+     * Weight(UID): 100
      *
      * @param int $startTime
      * @param int $endTime

--- a/src/Binance/Spot/Margin.php
+++ b/src/Binance/Spot/Margin.php
@@ -1009,4 +1009,20 @@ trait Margin
     {
         return $this->signRequest('GET', '/sapi/v1/margin/rateLimit/order', $options);
     }
+
+    /**
+     * Margin Dustlog (USER_DATA)
+     *
+     * GET /sapi/v1/margin/dribblet
+     *
+     * Query the historical information of user's margin account small-value asset conversion BNB.
+     *
+     * Weight(IP): 1
+     *
+     * @param array $options
+     */
+    public function marginDustLog(array $options = [])
+    {
+        return $this->signRequest('GET', '/sapi/v1/margin/dribblet', $options);
+    }
 }

--- a/src/Binance/Spot/Wallet.php
+++ b/src/Binance/Spot/Wallet.php
@@ -428,6 +428,22 @@ trait Wallet
     }
 
     /**
+     * User Asset (USER_DATA)
+     *
+     * POST /sapi/v3/asset/getUserAsset
+     *
+     * Get user assets, just for positive data.
+     *
+     * Weight(IP): 5
+     *
+     * @param array $options
+     */
+    public function userAsset(array $options = [])
+    {
+        return $this->signRequest('POST', '/sapi/v3/asset/getUserAsset', $options);
+    }
+
+    /**
      * Funding Wallet (USER_DATA)
      *
      * POST /sapi/v1/asset/get-funding-asset

--- a/tests/spot/margin/MarginDustLog.php
+++ b/tests/spot/margin/MarginDustLog.php
@@ -1,0 +1,40 @@
+<?php
+
+use Binance\Tests\BaseTestCase;
+use Aeris\GuzzleHttpMock\Expect;
+use Binance\Exception\MissingArgumentException;
+
+class MarginDustLogTest extends BaseTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    public function testMarginDustLog()
+    {
+        $this->httpMock
+            ->shouldReceiveRequest()
+            ->withUrl(new Expect\Equals('/sapi/v1/margin/dribblet'))
+            ->withMethod('GET')
+            ->withQueryParams(new Expect\ArrayEquals([
+                'startTime' => 1640995200000,
+                'endTime' => 1640995200000,
+                'recvWindow' => 5000
+            ]))
+            ->andRespondWithJson($this->data, $statusCode = 200);
+
+        $response = $this->spotClient->marginDustLog([
+            'startTime' => 1640995200000,
+            'endTime' => 1640995200000,
+            'recvWindow' => 5000
+        ]);
+
+        $this->assertEquals($response, $this->data);
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+    }
+}

--- a/tests/spot/wallet/UserAssetTest.php
+++ b/tests/spot/wallet/UserAssetTest.php
@@ -1,0 +1,40 @@
+<?php
+
+use Binance\Tests\BaseTestCase;
+use Aeris\GuzzleHttpMock\Expect;
+use Binance\Exception\MissingArgumentException;
+
+class UserAssetTest extends BaseTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    public function testUserAsset()
+    {
+        $this->httpMock
+            ->shouldReceiveRequest()
+            ->withUrl(new Expect\Equals('/sapi/v3/asset/getUserAsset'))
+            ->withMethod('POST')
+            ->withQueryParams(new Expect\ArrayEquals([
+                'asset' => 'BTC',
+                'needBtcValuation' => 'true',
+                'recvWindow' => '5000'
+            ]), ['timestamp', 'signature'])
+            ->andRespondWithJson($this->data, $statusCode = 200);
+
+        $response = $this->spotClient->userAsset([
+            'asset' => 'BTC',
+            'needBtcValuation' => true,
+            'recvWindow' => 5000
+        ]);
+
+        $this->assertEquals($response, $this->data);
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+    }
+}


### PR DESCRIPTION
New endpoint for Margin:
  - `POST /sapi/v3/asset/getUserAsset` to get user assets.

New endpoint for Wallet:
  - `GET /sapi/v1/margin/dribblet` to query the historical information of user's margin account small-value asset conversion BNB.

Update endpoint for Convert:
  - `GET /sapi/v1/fiat/orders`: Weight changes from IP(3000) to IP(100)